### PR TITLE
remove URL encode form Kodi volume instructions

### DIFF
--- a/kodivolume.md
+++ b/kodivolume.md
@@ -1,9 +1,11 @@
 # Kodi volume control using dim commands & JSON-RPC
 
 You can use HA Bridge to adjust the Kodi software volume output. This allows you to use dim commands and set the volume level with percentage values.
+
 ### What is JSON-RPC?
 
 The short answer is JSON-RPC an interface to communicate with Kodi. [See the official Kodi Wiki for more info](http://kodi.wiki/view/JSON-RPC_API) 
+
 ### Setup Kodi to allow control through JSON-RPC
 
 In Kodi navigate to Settings/Services/Control ([screenshot](http://kodi.wiki/view/Settings/Services/Control))
@@ -21,7 +23,7 @@ Make a note of the **PORT**
 Access the HA Bridge Configuration in your browser and open the  **Manual Add** tab.
 #### Name
 
-Give the device a unique name that doesnít include **ìvolumeî** as it will cause conflicts with the Echoís built in volume controls. A device name of **ìcody soundî** works well.
+Give the device a unique name that doesn‚Äôt include **‚Äúvolume‚Äù** as it will cause conflicts with the Echo‚Äôs built in volume controls. A device name of **‚Äúcody sound‚Äù** works well.
 #### Device type
 
 Select **TCP** in the dropdown
@@ -47,7 +49,7 @@ Before you continue, open your custom URL in a browser (making sure Kodi is runn
     "id": "http://xbmc.org/jsonrpc/ServiceDescription.json",
 ```
 
-If you donít see something that looks like the code above, then go back and double check your settings.
+If you don‚Äôt see something that looks like the code above, then go back and double check your settings.
 #### The JSON request
 
 The URL is what connects you to Kodi, JSON is what is used to communicate with it. The JSON that is used to set the volume level is:
@@ -62,14 +64,15 @@ Join the two together by adding `?request=` to the end of the URL and then add t
 ```
 http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request={"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":100},"id":1}
 ```
-##### Testing the request in a browser
+### Testing the request in a browser
 
 Go ahead and test the combined URL/JSON in a browser changing **100** to whatever level you want to set. Kodi should adjust the volume accordingly, try a few different levels to be sure it is working correctly. 
 
-The browser will reformat the URL each time you press return so donít build the URL in the browser bar without making a copy first. 
+The browser will reformat the URL each time you press return so don‚Äôt build the URL in the browser bar without making a copy first. 
 
 Ideally build the URL in a text document which you can easily edit and then copy/paste each time. 
-#### Prepare the three URLs
+
+### Prepare the three URLs
 
 You want to end up with three full URLs in your text file, one for each of the commands.
 
@@ -90,71 +93,52 @@ http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request={"jsonrpc"
 ```
 http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request={"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":0},"id":1}
 ```
-#### Encoding the JSON part
 
-You should now be able to control the volume of Kodi using the structured URL you built above in a browser. If you canít get it to work in a browser then you wonít be able to get it to work in HA Bridge.
+### Test the three URLS
 
-In order for HA Bridge to send the JSON request you need to encode the URL. This means we take this:
+You should now be able to control the volume of Kodi using the structured URL you built above in a browser.
 
-```
-http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request={"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":100},"id":1}
-```
+If you can‚Äôt get it to work in a browser then you won‚Äôt be able to get it to work in HA Bridge.
 
-And turn it into this:
 
-```
-http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request=%7B%22jsonrpc%22%3A%222.0%22%2C%22method%22%3A%22Application.SetVolume%22%2C%22params%22%3A%7B%22volume%22%3A100%7D%2C%22id%22%3A1%7D
-```
+### Manually adding the device
 
-Note that we are only encoding the JSON, the URL part we leave as is.
+Add a new manual device and give it a name e.g. ‚ÄúCody Sound‚Äù
 
-Using the online tool [www.url-encode-decode.com](http://www.url-encode-decode.com/), copy the JSON part (shown in bold below) and paste it into the left hand field.
+Set `Device type` to `Custom`
 
-http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request=**{"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":100},"id":1}**
-
-Click the **Encode url** button.
-
-Copy the output from the right hand box and paste it on a new line in your text file.
+Use the same URL for all three (ON, OFF, DIM)
 
 ```
-%7B%22jsonrpc%22%3A%222.0%22%2C%22method%22%3A%22Application.SetVolume%22%2C%22params%22%3A%7B%22volume%22%3A100%7D%2C%22id%22%3A1%7D
+http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request=
 ```
-#### Join the URL and JSON
 
-Finally you want to insert the URL part before the request (shown in bold below)
+* `HTTP Verb` to `POST`
+* `Content type` to `application/json`
 
-**http://KODI_USERNAME:KODI_PASSWORD@192.168.1.123:8080/jsonrpc?request=**%7B%22jsonrpc%22%3A%222.0%22%2C%22method%22%3A%22Application.SetVolume%22%2C%22params%22%3A%7B%22volume%22%3A100%7D%2C%22id%22%3A1%7D
+**Content body On**
+```json
+{"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":100},"id":1}
+```
+**Content body Dim**
+```json
+{"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":${intensity.percent}},"id":1}
+```
+**Content body Off**
+```json
+{"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":0},"id":1}
+```
+
+
 ### HA Bridge
 
-Paste the final URL in **On URL** field. Just do the one for now, add the device and in the Bridge Control tab click Save.
+Save and test the button in the Bridge Devices tab and hopefully it should turn the volume up in Kodi.
 
-Test the button in the Bridge Devices tab and hopefully it should turn the volume up in Kodi.
-
-Go ahead and repeat the steps for the **Off URL**. All the same steps but change 100% to 0%. If you want to use the previous URL you can, just find the 100% in the encoded URL.
-
-`Ö%22%3A%7B%22volume%22%3A`**100**`%7D%2C%22id%22%3A1%7D`
-
-and change it to 0
-
-`Ö%22%3A%7B%22volume%22%3A`**0**`%7D%2C%22id%22%3A1%7D`
-#### Dim JSON
-
-The Dim URL uses the `${intensity.percent}` to take the given number from your voice command and pass it to Kodi.
-
-Here is the JSON to ìDimî the volume 
-
-``` json
-{"jsonrpc":"2.0","method":"Application.SetVolume","params":{"volume":"${intensity.percent}""},"id":1}
-```
-
-You donít need to encode the `${intensity.percent}` part. This means you can simply replace the number value (100/0) with `${intensity.percent}` as shown below.
-
-`Ö%22%3A%7B%22volume%22%3A`**${intensity.percent}**`%7D%2C%22id%22%3A1%7D`
 ### Controlling the Device
 
 You can use the commands as listed in the [README](https://github.com/bwssytems/ha-bridge#ask-alexa)
 
-ìSet Cody Sound to 50 percentî
-ìCody Sound to 70 percentî
+‚ÄúSet Cody Sound to 50 percent‚Äù
+‚ÄúCody Sound to 70 percent‚Äù
 
-Remembering that ìTurn on Cody Soundî will set the volume to 100%, and ìTurn off Cody Soundî will mute.
+Remembering that ‚ÄúTurn on Cody Sound‚Äù will set the volume to 100%, and ‚ÄúTurn off Cody Sound‚Äù will mute.


### PR DESCRIPTION
HI, I have removed all the encode decode parts of the guide as these as no longer relevant.

Thanks for all the work you do, notably the speed you pushed out the harmony fix recently :)

 