### PR TITLE
Added error message for scene invocation, to allow Logitech Pop to work.

### DIFF
--- a/src/main/java/com/bwssystems/HABridge/hue/HueMulator.java
+++ b/src/main/java/com/bwssystems/HABridge/hue/HueMulator.java
@@ -118,6 +118,17 @@ public class HueMulator {
 			log.debug("group add requested from " + request.ip() + " user " + request.params(":userid") + " with body " + request.body());
 			return "[{\"success\":{\"id\":\"1\"}}]";
 		});
+		// http://ip_address:port/api/:userid/groups/<groupid>/action
+		// Dummy handler
+		// Error forces Logitech Pop to fall back to individual light control
+		// instead of scene-based control.
+		put(HUE_CONTEXT + "/:userid/groups/:groupid/action", "application/json", (request, response) -> {
+			response.header("Access-Control-Allow-Origin", request.headers("Origin"));
+			response.type("application/json");
+			response.status(HttpStatus.SC_OK);
+			log.debug("put to groups API from " + request.ip() + " user " + request.params(":userid") + " with body " + request.body());
+			return "[{\"error\":{\"address\": \"/groups/0/action/scene\", \"type\":7, \"description\": \"invalid value, dummy for parameter, scene\"}}]";
+		});		
 		// http://ip_address:port/api/{userId}/scenes returns json objects of
 		// all scenes configured
 		get(HUE_CONTEXT + "/:userid/scenes", "application/json", (request, response) -> {


### PR DESCRIPTION
Got it -- the correct error type is 7, according to a real bridge.  Returning this error makes the Pop fall back to toggling individual lights, which the ha-bridge supports just fine.  Implementing proper scene support might be more efficient in the long term, but for now this works and is a very minor update.