### PR TITLE
Add possibility to set qos and retained state of MQTT messages

### DIFF
--- a/src/main/java/com/bwssystems/HABridge/plugins/mqtt/MQTTHandler.java
+++ b/src/main/java/com/bwssystems/HABridge/plugins/mqtt/MQTTHandler.java
@@ -13,11 +13,12 @@ import org.slf4j.LoggerFactory;
 
 import com.bwssystems.HABridge.NamedIP;
 
+import java.util.Optional;
+
 public class MQTTHandler {
     private static final Logger log = LoggerFactory.getLogger(MQTTHandler.class);
 	private NamedIP myConfig;
 	private MqttClient myClient;
-    private int qos             = 1;
 
 	public MQTTHandler(NamedIP aConfig) {
 		super();
@@ -40,20 +41,19 @@ public class MQTTHandler {
         }
         try {
 			myClient.connect(connOpts);
-		} catch (MqttSecurityException e) {
-			log.error("Could not connect MQTT client for name: " + myConfig.getName() + " and ip: " + myConfig.getIp() + " with message: " + e.getMessage());
 		} catch (MqttException e) {
 			log.error("Could not connect MQTT client for name: " + myConfig.getName() + " and ip: " + myConfig.getIp() + " with message: " + e.getMessage());
 		}
 	}
 
-	public void publishMessage(String topic, String content) {
+	public void publishMessage(String topic, String content, Integer qos, Boolean retain) {
         MqttMessage message = new MqttMessage(StringEscapeUtils.unescapeJava(content).getBytes());
-        message.setQos(qos);
+
+		message.setQos(Optional.ofNullable(qos).orElse(1));
+        message.setRetained(Optional.ofNullable(retain).orElse(false));
+
         try {
 			myClient.publish(topic, message);
-		} catch (MqttPersistenceException e) {
-			log.error("Could not publish to MQTT client for name: " + myConfig.getName() + " and ip: " + myConfig.getIp() + " with message: " + e.getMessage());
 		} catch (MqttException e) {
 			log.error("Could not publish to MQTT client for name: " + myConfig.getName() + " and ip: " + myConfig.getIp() + " with message: " + e.getMessage());
 		}

--- a/src/main/java/com/bwssystems/HABridge/plugins/mqtt/MQTTHome.java
+++ b/src/main/java/com/bwssystems/HABridge/plugins/mqtt/MQTTHome.java
@@ -37,9 +37,7 @@ public class MQTTHome implements Home {
 			return;
 		log.debug("Shutting down MQTT handlers.");
 		if(handlers != null && !handlers.isEmpty()) {
-			Iterator<String> keys = handlers.keySet().iterator();
-			while(keys.hasNext()) {
-				String key = keys.next();
+			for (String key : handlers.keySet()) {
 				handlers.get(key).shutdown();
 			}
 		}
@@ -108,7 +106,7 @@ public class MQTTHome implements Home {
 					if (mqttHandler == null) {
 						log.warn("Should not get here, no mqtt hanlder available");
 					} else {
-						mqttHandler.publishMessage(mqttMessages[y].getTopic(), mqttMessages[y].getMessage());
+						mqttHandler.publishMessage(mqttMessages[y].getTopic(), mqttMessages[y].getMessage(), mqttMessages[y].getQos(), mqttMessages[y].getRetain());
 					}
         		}
  			}
@@ -130,13 +128,10 @@ public class MQTTHome implements Home {
 			aGsonHandler =
 					new GsonBuilder()
 					.create();
-			handlers = new HashMap<String, MQTTHandler>();
-			Iterator<NamedIP> theList = bridgeSettings.getBridgeSettingsDescriptor().getMqttaddress().getDevices().iterator();
-			while(theList.hasNext()) {
-				NamedIP aClientConfig = theList.next();
+			handlers = new HashMap<>();
+			for (NamedIP aClientConfig : bridgeSettings.getBridgeSettingsDescriptor().getMqttaddress().getDevices()) {
 				MQTTHandler aHandler = new MQTTHandler(aClientConfig);
-				if(aHandler != null)
-					handlers.put(aClientConfig.getName(), aHandler);
+				handlers.put(aClientConfig.getName(), aHandler);
 			}
 		}
 		return this;

--- a/src/main/java/com/bwssystems/HABridge/plugins/mqtt/MQTTMessage.java
+++ b/src/main/java/com/bwssystems/HABridge/plugins/mqtt/MQTTMessage.java
@@ -6,6 +6,8 @@ public class MQTTMessage {
 	private String message;
 	private Integer delay;
 	private Integer count;
+	private Integer qos;
+	private Boolean retain;
 	public String getClientId() {
 		return clientId;
 	}
@@ -35,5 +37,20 @@ public class MQTTMessage {
 	}
 	public void setCount(Integer count) {
 		this.count = count;
+	}
+	public Integer getQos() {
+		return qos;
+	}
+
+	public void setQos(Integer qos) {
+		this.qos = qos;
+	}
+
+	public Boolean getRetain() {
+		return retain;
+	}
+
+	public void setRetain(Boolean retain) {
+		this.retain = retain;
 	}
 }

--- a/src/main/resources/public/scripts/app.js
+++ b/src/main/resources/public/scripts/app.js
@@ -2498,9 +2498,9 @@ app.controller('MQTTController', function ($scope, $location, bridgeService, ngD
 		$scope.device = bridgeService.state.device;
 	};
 
-	$scope.buildMQTTPublish = function (mqttbroker, mqtttopic, mqttmessage) {
-		onpayload = "{\"clientId\":\"" + mqttbroker.clientId + "\",\"topic\":\"" + mqtttopic + "\",\"message\":\"" + mqttmessage + "\"}";
-		offpayload = "{\"clientId\":\"" + mqttbroker.clientId + "\",\"topic\":\"" + mqtttopic + "\",\"message\":\"" + mqttmessage + "\"}";
+	$scope.buildMQTTPublish = function (mqttbroker, mqtttopic, mqttmessage, mqttqos, mqttretain) {
+		onpayload = "{\"clientId\":\"" + mqttbroker.clientId + "\",\"topic\":\"" + mqtttopic + "\",\"message\":\"" + mqttmessage + "\",\"qos\":\"" + mqttqos + "\",\"retain\":\"" + mqttretain + "\"}";
+		offpayload = "{\"clientId\":\"" + mqttbroker.clientId + "\",\"topic\":\"" + mqtttopic + "\",\"message\":\"" + mqttmessage + "\",\"qos\":\"" + mqttqos + "\",\"retain\":\"" + mqttretain + "\"}";
 
 		bridgeService.buildUrls(onpayload, null, offpayload, true, mqttbroker.clientId + "-" + mqtttopic, mqttbroker.clientId + mqtttopic, mqttbroker.clientId, "mqtt",  "mqttMessage", null, null);
 		$scope.device = bridgeService.state.device;

--- a/src/main/resources/public/views/mqttpublish.html
+++ b/src/main/resources/public/views/mqttpublish.html
@@ -43,6 +43,8 @@
 				<th sortable-header col="ip">IP</th>
 				<th>Topic</th>
 				<th>Content</th>
+				<th>QoS</th>
+				<th>Retain</th>
 				<th>Build Actions</th>
 			</tr>
 		</thead>
@@ -59,8 +61,16 @@
 							ng-model="mqttcontent" placeholder="The MQTT Message Content"></textarea>
 			</td>
 			<td>
+				<input type="number" rows="1" class="form-control" id="mqtt-qos"
+					   ng-model="mqttqos" placeholder="1"/>
+			</td>
+			<td>
+				<input type="checkbox" rows="1" class="form-control" id="mqtt-retain"
+					   ng-model="mqttretain"/>
+			</td>
+			<td>
 				<button class="btn btn-success" type="submit"
-					ng-click="buildMQTTPublish(mqttbroker, mqtttopic, mqttcontent)">Build
+					ng-click="buildMQTTPublish(mqttbroker, mqtttopic, mqttcontent, mqttqos, mqttretain)">Build
 					publish Message</button>
 			</td>
 		</tr>


### PR DESCRIPTION
This PR adds the possibilities to set the retain flag and the QoS of the MQTT messages sent by ha-bridge. The message generator in the front-end has been adapted accordingly. 