### PR TITLE
Added quotes around strings in json response for huemulator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.bwssystems.HABridge</groupId>
 	<artifactId>ha-bridge</artifactId>
-	<version>5.2.1</version>
+	<version>5.2.2</version>
 	<packaging>jar</packaging>
 
 	<name>HA Bridge</name>

--- a/src/main/java/com/bwssystems/HABridge/hue/HueMulator.java
+++ b/src/main/java/com/bwssystems/HABridge/hue/HueMulator.java
@@ -570,8 +570,8 @@ public class HueMulator {
 		if (body.contains("\"effect\"")) {
 			if (notFirstChange)
 				responseString = responseString + ",";
-			responseString = responseString + "{\"success\":{\"/lights/" + lightId + "/state/effect\":"
-					+ stateChanges.getEffect() + "}}";
+			responseString = responseString + "{\"success\":{\"/lights/" + lightId + "/state/effect\":\""
+					+ stateChanges.getEffect() + "\"}}";
 			if (deviceState != null)
 				deviceState.setEffect(stateChanges.getEffect());
 			notFirstChange = true;
@@ -590,8 +590,8 @@ public class HueMulator {
 		if (body.contains("\"alert\"")) {
 			if (notFirstChange)
 				responseString = responseString + ",";
-			responseString = responseString + "{\"success\":{\"/lights/" + lightId + "/state/alert\":"
-					+ stateChanges.getAlert() + "}}";
+			responseString = responseString + "{\"success\":{\"/lights/" + lightId + "/state/alert\":\""
+					+ stateChanges.getAlert() + "\"}}";
 			if (deviceState != null)
 				deviceState.setAlert(stateChanges.getAlert());
 			notFirstChange = true;


### PR DESCRIPTION
When adding the HABridge to Home Assistant the Home Assistant kept crashing on the json response. The json response for state changes containing alert / effect was returning none instead of "none".