### PR TITLE
Bumped Guice to 5.1.0 to add Java 17 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>4.1.0</version>
+			<version>5.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>


### PR DESCRIPTION
When LinuxServer.io bumped their ha-bridge container to Java 17 in https://github.com/linuxserver/docker-habridge/pull/23 I noticed that ha-bridge isn't yet Java 17 compatibile. This mainly stems from the shaded cglib in Guice 4.1.0. Google published Guice 5.1.0 a while ago which removes cglib and adds official Java 17 support.

```
https://www.linuxserver.io/donate/
───────────────────────────────────────
GID/UID
───────────────────────────────────────
User UID:    1000
User GID:    1000
───────────────────────────────────────
[custom-init] No custom files found, skipping...
2024-04-05 11:09:22,808 [main] INFO  com.bwssystems.HABridge.HABridge - HA Bridge startup sequence...
2024-04-05 11:09:22,818 [main] INFO  com.bwssystems.HABridge.HABridge - HA Bridge (v5.4.1) initializing....
2024-04-05 11:09:22,818 [main] INFO  com.bwssystems.HABridge.BridgeSettings - reading from config file: /config/ha-bridge.config
2024-04-05 11:09:22,909 [main] INFO  spark.staticfiles.StaticFilesConfiguration - StaticResourceHandler configured with folder = /public
2024-04-05 11:09:22,915 [main] INFO  com.bwssystems.HABridge.SystemControl - System control service started....
2024-04-05 11:09:22,928 [main] INFO  com.bwssystems.HABridge.util.UDPDatagramSender - Initializing UDP response Socket...
2024-04-05 11:09:22.934:INFO::Thread-0: Logging initialized @313ms to org.eclipse.jetty.util.log.StdErrLog
2024-04-05 11:09:22,935 [main] INFO  com.bwssystems.HABridge.util.UDPDatagramSender - UDP response Socket initialized to: 50000
2024-04-05 11:09:22,937 [main] INFO  com.bwssystems.HABridge.plugins.http.HTTPHome - HTTP Home created.
2024-04-05 11:09:22,938 [main] INFO  com.bwssystems.HABridge.plugins.harmony.HarmonyHome - Harmony Home created.
2024-04-05 11:09:22,961 [Thread-0] INFO  spark.embeddedserver.jetty.EmbeddedJettyServer - == Spark has ignited ...
2024-04-05 11:09:22,961 [Thread-0] INFO  spark.embeddedserver.jetty.EmbeddedJettyServer - >> Listening on 0.0.0.0:8080
2024-04-05 11:09:22.963:INFO:oejs.Server:Thread-0: jetty-9.4.z-SNAPSHOT, build timestamp: 2017-11-21T22:27:37+01:00, git hash: 82b8fb23f757335bb3329d540ce37a2a2615f0a8
2024-04-05 11:09:22.976:INFO:oejs.session:Thread-0: DefaultSessionIdManager workerName=node0
2024-04-05 11:09:22.976:INFO:oejs.session:Thread-0: No SessionScavenger set, using defaults
2024-04-05 11:09:22.978:INFO:oejs.session:Thread-0: Scavenging every 600000ms
2024-04-05 11:09:22.996:INFO:oejs.AbstractConnector:Thread-0: Started ServerConnector@b51650{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
2024-04-05 11:09:22.996:INFO:oejs.Server:Thread-0: Started @376ms
Exception in thread "main" com.google.common.util.concurrent.ExecutionError: com.google.common.util.concurrent.ExecutionError: java.lang.ExceptionInInitializerError
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2215)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4154)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4158)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5147)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5153)
	at com.google.inject.internal.FailableCache.get(FailableCache.java:48)
	at com.google.inject.internal.MembersInjectorStore.get(MembersInjectorStore.java:68)
	at com.google.inject.internal.InjectorImpl.getMembersInjector(InjectorImpl.java:993)
	at com.google.inject.internal.InjectorImpl.getMembersInjector(InjectorImpl.java:1000)
	at com.google.inject.internal.InjectorImpl.injectMembers(InjectorImpl.java:986)
	at com.bwssystems.HABridge.plugins.harmony.HarmonyServer.setup(HarmonyServer.java:64)
	at com.bwssystems.HABridge.plugins.harmony.HarmonyHome.createHome(HarmonyHome.java:307)
	at com.bwssystems.HABridge.plugins.harmony.HarmonyHome.<init>(HarmonyHome.java:40)
	at com.bwssystems.HABridge.HomeManager.buildHomes(HomeManager.java:56)
	at com.bwssystems.HABridge.HABridge.main(HABridge.java:92)
Caused by: com.google.common.util.concurrent.ExecutionError: java.lang.ExceptionInInitializerError
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2215)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4154)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4158)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5147)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5153)
	at com.google.inject.internal.FailableCache.get(FailableCache.java:48)
	at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:50)
	at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:138)
	at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:550)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:887)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:808)
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:285)
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:217)
	at com.google.inject.internal.SingleFieldInjector.<init>(SingleFieldInjector.java:42)
	at com.google.inject.internal.MembersInjectorStore.getInjectors(MembersInjectorStore.java:131)
	at com.google.inject.internal.MembersInjectorStore.createWithListeners(MembersInjectorStore.java:98)
	at com.google.inject.internal.MembersInjectorStore.access$000(MembersInjectorStore.java:37)
	at com.google.inject.internal.MembersInjectorStore$1.create(MembersInjectorStore.java:45)
	at com.google.inject.internal.MembersInjectorStore$1.create(MembersInjectorStore.java:42)
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:37)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3716)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2424)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2298)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2211)

	... 14 more
Caused by: java.lang.ExceptionInInitializerError
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.getProtectionDomain(FastClass.java:73)
	at com.google.inject.internal.cglib.core.$AbstractClassGenerator.create(AbstractClassGenerator.java:206)
	at com.google.inject.internal.cglib.reflect.$FastClass$Generator.create(FastClass.java:65)
	at com.google.inject.internal.BytecodeGen.newFastClassForMember(BytecodeGen.java:252)
	at com.google.inject.internal.BytecodeGen.newFastClassForMember(BytecodeGen.java:203)
	at com.google.inject.internal.DefaultConstructionProxyFactory.create(DefaultConstructionProxyFactory.java:53)
	at com.google.inject.internal.ProxyFactory.create(ProxyFactory.java:158)
	at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:90)
	at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:29)
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:37)
	at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:33)
	at com.google.inject.internal.FailableCache$1.load(FailableCache.java:37)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3716)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2424)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2298)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2211)

	... 37 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @37d0ee48
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at com.google.inject.internal.cglib.core.$ReflectUtils$1.run(ReflectUtils.java:52)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at com.google.inject.internal.cglib.core.$ReflectUtils.<clinit>(ReflectUtils.java:42)

	... 53 more
Connection to localhost (::1) 8080 port [tcp/http-alt] succeeded!
[ls.io-init] done.
```

A quick smoke test with a ha-bridge jar using Guice 5.1.0 seems to run fine with Java 17 and works with Harmony, REST calls and MQTT integration