### PR TITLE
Fix CWE-22 path traversal in backup file endpoints

### DIFF
--- a/src/main/java/com/bwssystems/HABridge/util/BackupHandler.java
+++ b/src/main/java/com/bwssystems/HABridge/util/BackupHandler.java
@@ -34,6 +34,21 @@ public abstract class BackupHandler {
 		log.debug("setupParams has defaultName: " + defaultName + " and file extension as: " + fileExtension);
 	}
 
+	// Resolves aFilename against the backup directory, rejecting path
+	// traversal. Backslash is rejected outright: it is a path separator on
+	// Windows and a legitimate backup name never contains one.
+	private Path safeBackupPath(String aFilename) {
+		if (aFilename == null || aFilename.contains("\\")) {
+			return null;
+		}
+		Path parentDir = repositoryPath.getParent();
+		if (parentDir == null) {
+			return null;
+		}
+		Path resolved = parentDir.resolve(aFilename).normalize();
+		return resolved.startsWith(parentDir) ? resolved : null;
+	}
+
 	public String backup(String aFilename) {
         if(aFilename == null || aFilename.equalsIgnoreCase("")) {
         	DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
@@ -41,8 +56,13 @@ public abstract class BackupHandler {
         }
         else
         	aFilename = aFilename + fileExtension;
+        Path target = safeBackupPath(aFilename);
+        if (target == null) {
+        	log.warn("Error: Unsafe filename rejected (path traversal) - " + aFilename);
+        	return null;
+        }
     	try {
-			Files.copy(repositoryPath, FileSystems.getDefault().getPath(repositoryPath.getParent().toString(), aFilename), StandardCopyOption.COPY_ATTRIBUTES);
+			Files.copy(repositoryPath, target, StandardCopyOption.COPY_ATTRIBUTES);
 		} catch (IOException e) {
 			log.error("Could not backup to file: " + aFilename + " message: " + e.getMessage(), e);
 		}
@@ -52,8 +72,13 @@ public abstract class BackupHandler {
 
 	public String deleteBackup(String aFilename) {
         log.debug("Delete backup repository: " + aFilename);
+        Path filePath = safeBackupPath(aFilename);
+        if (filePath == null) {
+        	log.warn("Error: Unsafe filename rejected (path traversal) - " + aFilename);
+        	return null;
+        }
         try {
-			Files.delete(FileSystems.getDefault().getPath(repositoryPath.getParent().toString(), aFilename));
+			Files.delete(filePath);
 		} catch (IOException e) {
 			log.error("Could not delete file: " + aFilename + " message: " + e.getMessage(), e);
 		}
@@ -62,6 +87,11 @@ public abstract class BackupHandler {
 
 	public String restoreBackup(String aFilename) {
         log.debug("Restore backup repository: " + aFilename);
+        Path source = safeBackupPath(aFilename);
+        if (source == null) {
+        	log.warn("Error: Unsafe filename rejected (path traversal) - " + aFilename);
+        	return null;
+        }
 		try {
 			Path target = null;
 			if(Files.exists(repositoryPath)) {
@@ -69,7 +99,7 @@ public abstract class BackupHandler {
 				target = FileSystems.getDefault().getPath(repositoryPath.getParent().toString(), defaultName + dateFormat.format(Calendar.getInstance().getTime()) + fileExtension);
 				Files.move(repositoryPath, target);
 			}
-			Files.copy(FileSystems.getDefault().getPath(repositoryPath.getParent().toString(), aFilename), repositoryPath, StandardCopyOption.COPY_ATTRIBUTES);
+			Files.copy(source, repositoryPath, StandardCopyOption.COPY_ATTRIBUTES);
 		} catch (IOException e) {
 			log.error("Error restoring the file: " + aFilename + " message: " + e.getMessage(), e);
 			return null;
@@ -94,7 +124,11 @@ public abstract class BackupHandler {
 	}
 	
 	public String downloadBackup(String aFilename) {
-		Path filePath = FileSystems.getDefault().getPath(repositoryPath.getParent().toString(), aFilename);
+		Path filePath = safeBackupPath(aFilename);
+		if (filePath == null) {
+			log.warn("Error: Unsafe filename rejected (path traversal) - " + aFilename);
+			return null;
+		}
 
 		String content = null;
 		if (Files.notExists(filePath) || !Files.isReadable(filePath)) {
@@ -121,7 +155,13 @@ public abstract class BackupHandler {
 				aFilename = aFilename +fileExtension;
 			}
 		}
-		Path filePath = FileSystems.getDefault().getPath(repositoryPath.getParent().toString(), aFilename);
+
+		Path filePath = safeBackupPath(aFilename);
+		if (filePath == null) {
+			String error = "Error: Unsafe filename rejected (path traversal) - " + aFilename;
+			log.warn(error);
+			return error;
+		}
 
 		successMessage = uploadWriter(theContent, filePath);
 


### PR DESCRIPTION
Hi, Thanks for this awesome work, and there might be a path traversal problem when handling specific path.

## Summary

All backup endpoints under `/api/devices/backup/` pass attacker-controlled
filenames (`:filename` path param for `upload`; JSON-body `BackupFilename`
for `download`/`delete`/`restore`/`create`) into
`FileSystems.getDefault().getPath(backupDir, aFilename)` without validation,
allowing path traversal (CWE-22):

- `upload` → arbitrary file **write** (attacker content; forced `.bk` suffix, no overwrite)
- `download` → arbitrary file **read** (content returned in the response)
- `delete` → arbitrary file **delete**
- `restore` → device database **overwritten** with any local file
- `create` → database copied to an attacker-chosen path

ha-bridge has no authentication by default, so these are remotely
exploitable in default configurations.

## Proof of concept

Jetty decodes `%2F` to `/` before Spark binds route params, so `..%2F` works
as `../` inside a single path segment (a raw `../` returns 404 at routing):

```bash
# Pre-fix: HTTP 200, file written outside the backup dir. Post-fix: HTTP 424.
curl -i -X PUT -H "Content-Type: application/json" --data 'pwned' \
  'http://<host>:<port>/api/devices/backup/upload/..%2Fpwned.bk'

# Pre-fix: returns content of any readable file. Post-fix: empty body.
curl -i -X PUT -H "Content-Type: application/json" --data '{"filename":"../secret.txt"}' \
  'http://<host>:<port>/api/devices/backup/download'
```

Verified on the pom-pinned stack (Spark 2.7.2 + Jetty 9.4.8) at `d9e0985`.

## Fix

All five `BackupHandler` file operations now go through one shared helper —
resolve against the backup directory, normalize, and require the result to
stay under it; backslashes are rejected outright (path separator on Windows,
never legitimate in a backup name):

```java
private Path safeBackupPath(String aFilename) {
    if (aFilename == null || aFilename.contains("\\")) {
        return null;
    }
    Path parentDir = repositoryPath.getParent();
    if (parentDir == null) {
        return null;
    }
    Path resolved = parentDir.resolve(aFilename).normalize();
    return resolved.startsWith(parentDir) ? resolved : null;
}
```

Rejection follows each method's existing error convention (`upload` returns
its `Error:` message → HTTP 424; others return `null` / refuse the
operation). `restore` validates **before** moving the existing database
aside, so a rejected restore leaves the database untouched. No API changes.

## Verification

Tested against the real `DeviceRepository`/`BackupHandler` chain:

| Payload | Before-fix | After-fix |
|---|---|---|
| `upload ..%2Fpwned.bk` | 200, file written outside backup dir | 424, nothing written |
| `upload ..\\..\\etc\\passwd.bk` | 200 | 424 |
| `downloadBackup("../secret.txt")` | content leaked | `null` |
| `deleteBackup("../secret.txt")` | file deleted | refused, file intact |
| `restoreBackup("../secret.txt")` | database overwritten | `null`, DB untouched |
| `backup("../evil")` | path accepted | `null` |
| legit upload → download → delete → restore | works | works, unchanged |

Raw `../` and absolute-path uploads return 404 at Spark routing both before
and after the fix.

## Affected versions

Current master (`d9e0985`, 5.4.1-java11) and prior releases; exposure
depends on deployment (no auth unless users are configured).
